### PR TITLE
Updated to embed mongo 1.41

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -1,6 +1,6 @@
 h1. SCALATEST EMBED MONGO
 
-This project provides API to use an "embedMongo database":https://github.com/michaelmosmann/embedmongo.flapdoodle.de in your Scala tests
+This project provides API to use an "embedMongo database":https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo in your Scala tests
 
 It is directly inspired by "spec2-embedmongo":https://github.com/athieriot/specs2-embedmongo project.
 

--- a/project/ScalaTestEmbededMongoBuild.scala
+++ b/project/ScalaTestEmbededMongoBuild.scala
@@ -14,14 +14,15 @@ object ScalaTestEmbededMongoBuild extends Build {
 
             crossScalaVersions := Seq("2.9.1", "2.9.2", "2.10.1"),
 
-    	    resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
+    	      resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
 
             libraryDependencies <++= (scalaVersion) { scalaVersion => Seq(
-                "de.flapdoodle.embed" % "de.flapdoodle.embed.mongo" % "1.28",
+                "de.flapdoodle.embed" % "de.flapdoodle.embed.mongo" % "1.41",
                 "org.scalatest" %% "scalatest" % CrossDependencies.scalatest_version(scalaVersion) % "test",
-                "com.novus" %% "salat" % "1.9.2-SNAPSHOT" % "test"
-            )
+                "com.novus" %% "salat" % "1.9.5" % "test")
             },
+
+            parallelExecution := false,
 
             publishMavenStyle := true,
             publishArtifact in Test := false,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,3 @@
-resolvers += Resolver.url("sbt-plugin-releases", new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
-
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.7")
-
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.1.0")
-
-resolvers += Classpaths.typesafeResolver
+addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
 
 addSbtPlugin("com.github.scct" % "sbt-scct" % "0.2")

--- a/src/main/scala/com/github/simplyscala/MongoEmbedDatabase.scala
+++ b/src/main/scala/com/github/simplyscala/MongoEmbedDatabase.scala
@@ -2,7 +2,8 @@ package com.github.simplyscala
 
 import de.flapdoodle.embed.mongo.distribution.Version
 import de.flapdoodle.embed.mongo.{MongodProcess, MongodExecutable, MongodStarter}
-import de.flapdoodle.embed.mongo.config.MongodConfig
+import de.flapdoodle.embed.mongo.config.{Net, MongodConfigBuilder}
+import de.flapdoodle.embed.process.runtime.Network
 
 /**
  * Extends this trait provide to your test class a connection to embedMongo database
@@ -10,9 +11,14 @@ import de.flapdoodle.embed.mongo.config.MongodConfig
 trait MongoEmbedDatabase {
 
     private def runtime(): MongodStarter = MongodStarter.getDefaultInstance
-    private def mongodExec(port: Int, version: Version): MongodExecutable = runtime().prepare(new MongodConfig(version, port, true))
+    private def mongodExec(port: Int, version: Version): MongodExecutable = runtime().prepare(
+      new MongodConfigBuilder()
+            .version(version)
+            .net(new Net(port, Network.localhostIsIPv6()))
+            .build())
 
-    protected def mongoStart(port: Int = 12345, version: Version = Version.V2_3_0): MongodProps = {
+
+    protected def mongoStart(port: Int = 12345, version: Version = Version.V2_4_8): MongodProps = {
         val mongodExe = mongodExec(port, version)
         MongodProps(mongodExe.start(), mongodExe)
     }
@@ -22,9 +28,9 @@ trait MongoEmbedDatabase {
         Option(mongodProps).foreach( _.mongodExe.stop() )
     }
 
-    protected def withEmbedMongoFixture(port: Int = 12345, version: Version = Version.V2_3_0)(fixture: MongodProps => Any) {
+    protected def withEmbedMongoFixture(port: Int = 12345, version: Version = Version.V2_4_8)(fixture: MongodProps => Any) {
         val mongodProps = mongoStart(port, version)
-        try { fixture(mongodProps) } finally { Option(mongodProps).foreach( mongoStop(_) ) }
+        try { fixture(mongodProps) } finally { Option(mongodProps).foreach( mongoStop ) }
     }
 }
 

--- a/src/test/scala/com/github/simplyscala/DummyModel.scala
+++ b/src/test/scala/com/github/simplyscala/DummyModel.scala
@@ -1,0 +1,9 @@
+package com.github.simplyscala
+
+import com.novus.salat.dao.SalatDAO
+import com.mongodb.casbah.MongoConnection
+import com.mongodb.casbah.Imports._
+import com.novus.salat.global._
+
+case class DummyModel(id: ObjectId = new ObjectId, name: String)
+object DummyModel extends SalatDAO[DummyModel, ObjectId](collection = MongoConnection("localhost", 12345)("test")("model")) {}

--- a/src/test/scala/com/github/simplyscala/MongoEmbedDatabaseImmutableTest.scala
+++ b/src/test/scala/com/github/simplyscala/MongoEmbedDatabaseImmutableTest.scala
@@ -2,37 +2,30 @@ package com.github.simplyscala
 
 import org.scalatest.FunSuite
 import org.scalatest.matchers.ShouldMatchers
-import com.novus.salat.dao.SalatDAO
-import com.mongodb.casbah.MongoConnection
-import com.mongodb.casbah.Imports._
-import com.novus.salat.global._
 import org.scalatest.exceptions.TestFailedException
 
 class MongoEmbedDatabaseImmutableTest extends FunSuite with ShouldMatchers with MongoEmbedDatabase {
     test("fixture test with bad port") {
         evaluating {
             withEmbedMongoFixture(22222) { mongodProps =>
-                Model2.save(Model2(name = "testFixture"))
-                Model2.count() should be (1)
+                DummyModel.save(DummyModel(name = "testFixture"))
+                DummyModel.count() should be (1)
             }
         } should produce[com.mongodb.MongoException]
     }
 
     test("fixture test") {
-        withEmbedMongoFixture(54321) { mongodProps =>
-            Model2.save(Model2(name = "testFixture"))
-            Model2.count() should be (1)
+        withEmbedMongoFixture(12345) { mongodProps =>
+            DummyModel.save(DummyModel(name = "testFixture"))
+            DummyModel.count() should be (1)
         }
     }
 
     test("launch fail() in fixture") {
         evaluating {
-            withEmbedMongoFixture(54321) { mongodProps =>
+            withEmbedMongoFixture(12345) { mongodProps =>
                 fail("fail")
             }
         } should produce[TestFailedException]
     }
 }
-
-case class Model2(id: ObjectId = new ObjectId, name: String)
-object Model2 extends SalatDAO[Model2, ObjectId](collection = MongoConnection("localhost", 54321)("test")("model")) {}

--- a/src/test/scala/com/github/simplyscala/MongoEmbedDatabaseTest.scala
+++ b/src/test/scala/com/github/simplyscala/MongoEmbedDatabaseTest.scala
@@ -2,10 +2,6 @@ package com.github.simplyscala
 
 import org.scalatest.{BeforeAndAfter, FunSuite}
 import org.scalatest.matchers.ShouldMatchers
-import com.mongodb.casbah.MongoConnection
-import com.mongodb.casbah.Imports._
-import com.novus.salat.global._
-import com.novus.salat.dao._
 
 class MongoEmbedDatabaseTest extends FunSuite with ShouldMatchers with BeforeAndAfter with MongoEmbedDatabase {
 
@@ -20,10 +16,9 @@ class MongoEmbedDatabaseTest extends FunSuite with ShouldMatchers with BeforeAnd
     }
 
     test("test connection with embed mongodb") {
-        Model.save(Model(name = "test"))
-        Model.count() should be (1)
+        DummyModel.save(DummyModel(name = "test"))
+        DummyModel.count() should be (1)
     }
 }
 
-case class Model(id: ObjectId = new ObjectId, name: String)
-object Model extends SalatDAO[Model, ObjectId](collection = MongoConnection("localhost", 12345)("test")("model")) {}
+


### PR DESCRIPTION
fixes #2.

I also disabled parallel tests and set both tests to run on the same port - when having parallel tests it may happen that a new Mongo version that wasn't used before will be downloaded twice.
