### PR TITLE
Update embedmongo version

### DIFF
--- a/project/ScalaTestEmbededMongoBuild.scala
+++ b/project/ScalaTestEmbededMongoBuild.scala
@@ -16,7 +16,7 @@ object ScalaTestEmbededMongoBuild extends Build {
             crossScalaVersions := Seq("2.10.4", "2.11.1"),
 
             libraryDependencies ++= Seq(
-                "de.flapdoodle.embed"   % "de.flapdoodle.embed.mongo"   % "1.46.0",
+                "de.flapdoodle.embed"   % "de.flapdoodle.embed.mongo"   % "1.50.0",
                 "org.scalatest"         %% "scalatest"                  % "2.1.7"       % "test",
                 "com.novus"             %% "salat"                      % "1.9.8"       % "test"
             ),

--- a/src/main/scala/com/github/simplyscala/MongoEmbedDatabase.scala
+++ b/src/main/scala/com/github/simplyscala/MongoEmbedDatabase.scala
@@ -20,7 +20,7 @@ trait MongoEmbedDatabase {
         .build()
 
     protected def mongoStart(port: Int = 12345,
-                             version: Version = Version.V2_4_8,
+                             version: Version = Version.V3_1_6,
                              runtimeConfig: IRuntimeConfig = runtimeConfig): MongodProps = {
         val mongodExe: MongodExecutable = mongodExec(port, version, runtimeConfig)
         MongodProps(mongodExe.start(), mongodExe)
@@ -32,7 +32,7 @@ trait MongoEmbedDatabase {
     }
 
     protected def withEmbedMongoFixture(port: Int = 12345,
-                                        version: Version = Version.V2_4_8,
+                                        version: Version = Version.V3_1_6,
                                         runtimeConfig: IRuntimeConfig = runtimeConfig)
                                        (fixture: MongodProps => Any) {
         val mongodProps = mongoStart(port, version, runtimeConfig)


### PR DESCRIPTION
Reactivemongo does not support MongoDB version 2.4 anymore as the end of life is reached. Using the recent version (3.1.6) is only possible when updating the version of embedmongo.